### PR TITLE
Remove SolidVM Pragmas for Compatibility with STRATO v9.0.0

### DIFF
--- a/template/backend/dapp/assets/{{name}}/contracts/{{name}}.hbs.sol
+++ b/template/backend/dapp/assets/{{name}}/contracts/{{name}}.hbs.sol
@@ -1,4 +1,3 @@
-pragma solidvm 3.4;
 
 import "/blockapps-sol/lib/rest/contracts/RestStatus.sol";
 import "/dapp/dapp/contracts/Dapp.sol";

--- a/template/backend/dapp/assets/{{name}}/contracts/{{name}}_{{reference}}_Ref.hbs.sol
+++ b/template/backend/dapp/assets/{{name}}/contracts/{{name}}_{{reference}}_Ref.hbs.sol
@@ -1,4 +1,3 @@
-pragma solidvm 3.4;
 
 import "/blockapps-sol/lib/rest/contracts/RestStatus.sol";
 

--- a/template/backend/dapp/dapp/contracts/Dapp.hbs.sol
+++ b/template/backend/dapp/dapp/contracts/Dapp.hbs.sol
@@ -1,4 +1,3 @@
-pragma solidvm 3.4;
 
 import "/blockapps-sol/lib/rest/contracts/RestStatus.sol";
 


### PR DESCRIPTION
STRATO v9.0.0 deprecated SolidVM pragmas, thus they must be removed for compatibility with Mercata.